### PR TITLE
Suggested improvement for the entrypoint

### DIFF
--- a/my-entrypoint.sh
+++ b/my-entrypoint.sh
@@ -7,4 +7,4 @@ neo4j-admin restore --from=/backup/neo4j --database=neo4j --force
 
 chown -R neo4j:neo4j /data
 
-/docker-entrypoint.sh neo4j
+exec /docker-entrypoint.sh $*


### PR DESCRIPTION
Two suggest improvements:
1. `exec` means you don't have the parent shell script running forever waiting for the server to come down
2. `$*` so that you can pass in a command other than `neo4j` (such as `sh`)